### PR TITLE
ui-kit.alpha domain A record to CNAME

### DIFF
--- a/aws/lubycon/mgmt/Global/route53/records.tf
+++ b/aws/lubycon/mgmt/Global/route53/records.tf
@@ -49,9 +49,9 @@ module "alpha-lubycon-io-records" {
     },
     {
       name = "ui-kit"
-      type = "A"
+      type = "CNAME"
       ttl  = 30
-      records = var.github_pages_ip_addresses
+      records = [var.lubycon_io_github_pages_domain]
     },
   ]
 }

--- a/aws/lubycon/mgmt/Global/route53/vars.tf
+++ b/aws/lubycon/mgmt/Global/route53/vars.tf
@@ -15,6 +15,9 @@ variable "alpha_lubycon_io_domain" {
 ####################
 # General
 ####################
+variable "lubycon_io_github_pages_domain" {
+  default = "lubycon.github.io"
+}
 variable "github_pages_ip_addresses"{
   default = ["185.199.108.153", "185.199.109.153", "185.199.110.153", "185.199.111.153",]
 }


### PR DESCRIPTION
동일한 zone에 대해 같은 CNAME을 사용할 수 없다..?
빌드가 덜 빈번한 lubycon home을 A로 유지.
ui-kit production 올라올 때 또 바뀌겠다.....
좋은 방법이 없을까?
